### PR TITLE
Forward compatibility for dbplyr 2.5.0

### DIFF
--- a/R/objects.R
+++ b/R/objects.R
@@ -111,7 +111,7 @@ setGeneric(name = "Patient", def = Patient)
 #' @export
 setClass(
   "Encounter", 
-  slot = c(longitudinal_table = "tbl"),
+  slots = c(longitudinal_table = "tbl"),
   contains = "RamsesObject"
 )
 
@@ -279,7 +279,7 @@ MedicationRequest <- function(conn, id) {
 #' @export
 setClass(
   "TherapyEpisode",
-  slot = c(longitudinal_table = "tbl"),
+  slots = c(longitudinal_table = "tbl"),
   contains = "RamsesObject"
 )
 

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,0 +1,1 @@
+test.duckdb.wal

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,0 +1,11 @@
+expect_table <- function(x, table) {
+  
+  if (packageVersion("dbplyr") > "2.4.0") {
+    expect_is(x, "dbplyr_table_path")
+    expect_equal(as.character(x), table)
+  } else {
+    expect_is(x, "dbplyr_table_ident")
+    expect_equal(vctrs::field(x, "table"), table)
+  }
+
+}

--- a/tests/testthat/test-objects.R
+++ b/tests/testthat/test-objects.R
@@ -68,16 +68,11 @@ test_that("Patient..interface_methods DuckDB", {
   expect_equal(capture.output(patient_object)[1],
                "Patient 99999999999 ")
   # COMPUTE 
-  expect_is(patient_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(patient_object@record$lazy_query$x$x, "table"), "patients")
+  expect_table(patient_object@record$lazy_query$x$x, "patients")
   
   patient_object_computed <- compute(patient_object)
-  
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(patient_object_computed@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(patient_object_computed@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(patient_object),
@@ -117,16 +112,11 @@ test_that("Patient..interface_methods Postgres", {
   expect_equal(capture.output(patient_object)[1],
                "Patient 99999999999 ")
   # COMPUTE 
-  expect_is(patient_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(patient_object@record$lazy_query$x$x, "table"), "patients")
+  expect_table(patient_object@record$lazy_query$x$x, "patients")
   
   patient_object_computed <- compute(patient_object)
-  
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(patient_object_computed@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(patient_object_computed@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(patient_object),
@@ -274,18 +264,11 @@ test_that("MedicationRequest..interface_methods DuckDB", {
   )
   
   # COMPUTE 
-  expect_is(med_req_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(
-    vctrs::field(med_req_object@record$lazy_query$x$x, "table"),
-    "drug_prescriptions"
-  )
+  expect_table(med_req_object@record$lazy_query$x$x, "drug_prescriptions")
   
   med_req_object_computed <- compute(med_req_object)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(med_req_object_computed@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(med_req_object_computed@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(med_req_object),
@@ -377,15 +360,11 @@ test_that("MedicationRequest..interface_methods Postgres", {
   )
   
   # COMPUTE 
-  expect_is(med_req_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(med_req_object@record$lazy_query$x$x, "table"), "drug_prescriptions")
+  expect_table(med_req_object@record$lazy_query$x$x, "drug_prescriptions")
 
   med_req_object_computed <- compute(med_req_object)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(med_req_object_computed@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(med_req_object_computed@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(med_req_object),
@@ -526,33 +505,18 @@ test_that("TherapyEpisode..interface_methods DuckDB", {
   )
   
   # COMPUTE 
-  expect_is(therapy_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(therapy_object@record$lazy_query$x$x, "table"),
-               "drug_therapy_episodes")
+  expect_table(therapy_object@record$lazy_query$x$x, "drug_therapy_episodes")
   therapy_object_computed <- compute(therapy_object)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(therapy_object_computed@record$lazy_query$x, "table"))
-  )
-  
-  expect_is(therapy_object_multi@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(therapy_object_multi@record$lazy_query$x$x, "table"), 
-               "drug_therapy_episodes")
+  expect_s3_class(therapy_object_computed@record, "tbl_duckdb_connection")
+
+  expect_table(therapy_object_multi@record$lazy_query$x$x, "drug_therapy_episodes")
   therapy_object_multi_computed <- compute(therapy_object_multi)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(therapy_object_multi_computed@record$lazy_query$x, "table"))
-  )
+  expect_s3_class(therapy_object_multi_computed@record, "tbl_duckdb_connection")
   
-  expect_is(therapy_object_multi4@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(therapy_object_multi4@record$lazy_query$x$x, "table"), 
-               "drug_therapy_episodes")
+  expect_table(therapy_object_multi4@record$lazy_query$x$x, "drug_therapy_episodes")
   therapy_object_multi_computed4 <- compute(therapy_object_multi4)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(therapy_object_multi_computed4@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(therapy_object_multi_computed4@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(therapy_object),
@@ -685,30 +649,18 @@ test_that("TherapyEpisode..interface_methods Postgres", {
   )
   
   # COMPUTE 
-  expect_is(therapy_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(therapy_object@record$lazy_query$x$x, "table"), "drug_therapy_episodes")
+  expect_table(therapy_object@record$lazy_query$x$x, "drug_therapy_episodes")
   therapy_object_computed <- compute(therapy_object)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(therapy_object_computed@record$lazy_query$x, "table"))
-  )
-  
-  expect_is(therapy_object_multi@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(therapy_object_multi@record$lazy_query$x$x, "table"), "drug_therapy_episodes")
+  expect_s3_class(therapy_object_computed@record, "tbl_duckdb_connection")
+
+  expect_table(therapy_object_multi@record$lazy_query$x$x, "drug_therapy_episodes")
   therapy_object_multi_computed <- compute(therapy_object_multi)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(therapy_object_multi_computed@record$lazy_query$x, "table"))
-  )
+  expect_s3_class(therapy_object_multi_computed@record, "tbl_duckdb_connection")
   
-  expect_is(therapy_object_multi4@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(therapy_object_multi4@record$lazy_query$x$x, "table"), "drug_therapy_episodes")
+  expect_table(therapy_object_multi4@record$lazy_query$x$x, "drug_therapy_episodes")
   therapy_object_multi_computed4 <- compute(therapy_object_multi4)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(therapy_object_multi_computed4@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(therapy_object_multi_computed4@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(therapy_object),
@@ -874,30 +826,18 @@ test_that("Encounter..interface_methods DuckDB", {
   )
   
   # COMPUTE 
-  expect_is(encounter_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(encounter_object@record$lazy_query$x$x, "table"), "inpatient_episodes")
+  expect_table(encounter_object@record$lazy_query$x$x, "inpatient_episodes")
   encounter_object_computed <- compute(encounter_object)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(encounter_object_computed@record$lazy_query$x, "table"))
-  )
-  
-  expect_is(encounter_object_multi@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(encounter_object_multi@record$lazy_query$x$x, "table"), "inpatient_episodes")
+  expect_s3_class(encounter_object_computed@record, "tbl_duckdb_connection")
+
+  expect_table(encounter_object_multi@record$lazy_query$x$x, "inpatient_episodes")
   encounter_object_multi_computed <- compute(encounter_object_multi)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(encounter_object_multi_computed@record$lazy_query$x, "table"))
-  )
-  
-  expect_is(encounter_object_multi5@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(encounter_object_multi5@record$lazy_query$x$x, "table"), "inpatient_episodes")
+  expect_s3_class(encounter_object_multi_computed@record, "tbl_duckdb_connection")
+
+  expect_table(encounter_object_multi5@record$lazy_query$x$x, "inpatient_episodes")
   encounter_object_multi5_computed <- compute(encounter_object_multi5)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(encounter_object_multi5_computed@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(encounter_object_multi5_computed@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(encounter_object),
@@ -1037,30 +977,18 @@ test_that("Encounter..interface_methods Postgres", {
   )
   
   # COMPUTE 
-  expect_is(encounter_object@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(encounter_object@record$lazy_query$x$x, "table"), "inpatient_episodes")
+  expect_table(encounter_object@record$lazy_query$x$x, "inpatient_episodes")
   encounter_object_computed <- compute(encounter_object)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(encounter_object_computed@record$lazy_query$x, "table"))
-  )
-  
-  expect_is(encounter_object_multi@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(encounter_object_multi@record$lazy_query$x$x, "table"), "inpatient_episodes")
+  expect_s3_class(encounter_object_computed@record, "tbl_duckdb_connection")
+
+  expect_table(encounter_object_multi@record$lazy_query$x$x, "inpatient_episodes")
   encounter_object_multi_computed <- compute(encounter_object_multi)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(encounter_object_multi_computed@record$lazy_query$x, "table"))
-  )
-  
-  expect_is(encounter_object_multi5@record$lazy_query$x$x, "dbplyr_table_ident")
-  expect_equal(vctrs::field(encounter_object_multi5@record$lazy_query$x$x, "table"), "inpatient_episodes")
+  expect_s3_class(encounter_object_multi_computed@record, "tbl_duckdb_connection")
+
+  expect_table(encounter_object_multi5@record$lazy_query$x$x, "inpatient_episodes")
   encounter_object_multi5_computed <- compute(encounter_object_multi5)
-  expect_true(
-    grepl("^dbplyr_", 
-          vctrs::field(encounter_object_multi5_computed@record$lazy_query$x, "table"))
-  )
-  
+  expect_s3_class(encounter_object_multi5_computed@record, "tbl_duckdb_connection")
+
   # COLLECT
   expect_equal(
     collect(encounter_object),


### PR DESCRIPTION
I had to read between the lines of the tests a bit, but this should paper over the differences between dbplyr 2.4.0 and 2.5.0.

(Also fixed some partial argument name matching warnings)